### PR TITLE
Adding a CI workflow to check for compilation errors

### DIFF
--- a/.github/workflows/tex_doc.yml
+++ b/.github/workflows/tex_doc.yml
@@ -16,4 +16,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: compile document with pdflatex
-        run: pdflatex -halt-on-error biegel_resume.tex
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: biegel_resume.tex

--- a/.github/workflows/tex_doc.yml
+++ b/.github/workflows/tex_doc.yml
@@ -1,0 +1,19 @@
+# Github Action to ensure the document compiles without breaking errors.
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Run CI when pull requests are issued against the 'main' branch
+  pull_request:
+    branches: [ "main" ]
+
+# Sequence of events in the Action
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: compile document with pdflatex
+        run: pdflatex -halt-on-error biegel_resume.tex

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pdf
 *.aux
 *.log
+*.out
 archive/

--- a/biegel_resume.tex
+++ b/biegel_resume.tex
@@ -1,7 +1,7 @@
 %----------------------------------------------------------------------------------------
 %	PACKAGES AND OTHER DOCUMENT CONFIGURATIONS
 %----------------------------------------------------------------------------------------
-\dshf
+
 \documentclass{resume} % Use the custom resume.cls style
 
 \usepackage{hyperref}

--- a/biegel_resume.tex
+++ b/biegel_resume.tex
@@ -1,7 +1,7 @@
 %----------------------------------------------------------------------------------------
 %	PACKAGES AND OTHER DOCUMENT CONFIGURATIONS
 %----------------------------------------------------------------------------------------
-
+\dshf
 \documentclass{resume} % Use the custom resume.cls style
 
 \usepackage{hyperref}


### PR DESCRIPTION
This merge request implements simple CI with an action which fails if any errors occur during document compilation.

The workflow uses the [xu-cheng/latex-action](https://github.com/marketplace/actions/github-action-for-latex) to import LaTeX and all subsidiary libraries and manage `pdflatex`. The Action will fail if any errors occur during compilation of the document, but not if any Warnings or lower-severity events occur.